### PR TITLE
Redirect na wykop po https zamiast http po dodaniu treningu

### DIFF
--- a/src/WykopBundle/Controller/TrainingController.php
+++ b/src/WykopBundle/Controller/TrainingController.php
@@ -295,7 +295,7 @@ class TrainingController extends Controller {
 	    if( $wykop->isValid() ) {
 		$em->persist($training);
 		$em->flush();
-		return $this->redirect('http://wykop.pl/wpis/' . (int) $result['id']);
+		return $this->redirect('https://wykop.pl/wpis/' . (int) $result['id']);
 	    } else {
 		$error = new FormError('Wykop: ' . $wykop->getError());
 		$form->addError($error);


### PR DESCRIPTION
Mała poprawka zachowania po dodaniu treningu. W niektórych sieciach z których się łącznie wykop po http jest zablokowany i dostaje stroną błędu. Także zmieniłem protokół na `https`

Inna bajką jest [przeniesienie tego adresu oraz adresu api do jakiegos yamla](https://github.com/tosyu/ruszdupe-web/issues/1) oraz[ zmiana api również na https (tak dla pewności bezpieczeństwa)](https://github.com/tosyu/ruszdupe-web/issues/2), ale te rzeczy zapisałem sobie w issue swojego forka i jak będę miał chwilę to dorobię.

Signed-off-by: Krzysztof Antoszek <krzysztof@antoszek.net>